### PR TITLE
Boost 1.67 compatibility

### DIFF
--- a/gr-blocks/lib/message_strobe_impl.cc
+++ b/gr-blocks/lib/message_strobe_impl.cc
@@ -90,7 +90,7 @@ namespace gr {
     void message_strobe_impl::run()
     {
       while(!d_finished) {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(d_period_ms));
+        boost::this_thread::sleep(boost::posix_time::milliseconds(static_cast<long>(d_period_ms)));
         if(d_finished) {
           return;
         }

--- a/gr-blocks/lib/message_strobe_random_impl.cc
+++ b/gr-blocks/lib/message_strobe_random_impl.cc
@@ -108,7 +108,7 @@ namespace gr {
     void message_strobe_random_impl::run()
     {
       while(!d_finished) {
-        boost::this_thread::sleep(boost::posix_time::milliseconds(std::max(0.0f,next_delay())));
+        boost::this_thread::sleep(boost::posix_time::milliseconds(static_cast<long>(std::max(0.0f,next_delay()))));
         if(d_finished) {
           return;
         }

--- a/gr-uhd/lib/usrp_block_impl.cc
+++ b/gr-uhd/lib/usrp_block_impl.cc
@@ -129,7 +129,7 @@ bool usrp_block_impl::_wait_for_locked_sensor(
 
   while (true) {
     if ((not first_lock_time.is_not_a_date_time()) and
-        (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(LOCK_TIMEOUT)))) {
+        (boost::get_system_time() > (first_lock_time + boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT))))) {
       break;
     }
 
@@ -140,7 +140,7 @@ bool usrp_block_impl::_wait_for_locked_sensor(
     else {
       first_lock_time = boost::system_time(); //reset to 'not a date time'
 
-      if (boost::get_system_time() > (start + boost::posix_time::seconds(LOCK_TIMEOUT))){
+      if (boost::get_system_time() > (start + boost::posix_time::seconds(static_cast<long>(LOCK_TIMEOUT)))){
         return false;
       }
     }


### PR DESCRIPTION
Note: this is a cherry-pick from gnuradio upstream,
  commit https://github.com/gnuradio/gnuradio/commit/86fa85feef81e69dd1354b393118459340b94489

On Travis CI, updating boost, yields a pretty new boost (1.67) which
breaks during build. This is on OS X builds using `brew`.

Error is:
```
~/scopy/deps/gnuradio/gr-blocks/lib/message_strobe_impl.cc:93:35: error: no matching conversion for functional-style cast from 'float' to 'boost::posix_time::milliseconds' (aka 'subsecond_duration<boost::posix_time::time_duration, 1000>')
        boost::this_thread::sleep(boost::posix_time::milliseconds(d_period_ms));
```

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>