### PR TITLE
Updates for GNU Radio version >= 3.9 compatibility.

### DIFF
--- a/cmake/Modules/FindAD9361.cmake
+++ b/cmake/Modules/FindAD9361.cmake
@@ -1,11 +1,44 @@
-# - Config file for the libad9361-iio package
-# It defines the following variables
-#  AD9361_INCLUDE_DIRS - include directories for FooBar
-#  AD9361_LIBRARIES    - libraries to link against
-#  LIBAD9361_FOUND     - system has libad9361 installed
+# - Find libad9361-iio
+# Find the native libad9361-iio includes and library
+#
+#  LIBAD9361_FOUND       - True if libad9361-iio is found.
+#  LIBAD9361_INCLUDE_DIR - Where to find ad9361.h.
+#  LIBAD9361_LIBRARIES   - List of libraries when using libad9361-iio.
 
-find_library(AD9361_LIBRARIES ad9361)
-find_path(AD9361_INCLUDE_DIRS ad9361.h)
-if(AD9361_LIBRARIES)
-    set(LIBAD9361_FOUND TRUE)
-endif(AD9361_LIBRARIES)
+set(LIBAD9361_NAMES ad9361)
+find_library(LIBAD9361_LIBRARY
+  NAMES ${LIBAD9361_NAMES}
+  PATHS /usr/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/local/lib64
+        /opt/local/lib
+        /opt/local/lib64
+)
+
+find_path(LIBAD9361_INCLUDE_DIR ad9361.h
+  /usr/include
+  /usr/local/include
+  /opt/local/include
+)
+
+if (LIBAD9361_INCLUDE_DIR AND LIBAD9361_LIBRARY)
+  set(LIBAD9361_FOUND TRUE)
+  set(LIBAD9361_INCLUDE_DIRS ${LIBAD9361_INCLUDE_DIR})
+  set(LIBAD9361_LIBRARIES ${LIBAD9361_LIBRARY})
+else ()
+  set(LIBAD9361_FOUND FALSE)
+  set(LIBAD9361_INCLUDE_DIR "")
+  set(LIBAD9361_INCLUDE_DIRS "")
+  set(LIBAD9361_LIBRARY "")
+  set(LIBAD9361_LIBRARIES "")
+endif ()
+
+if (LIBAD9361_FOUND)
+  message(STATUS "Found libad9361-iio library: ${LIBAD9361_LIBRARIES}")
+endif ()
+
+mark_as_advanced(
+  LIBAD9361_INCLUDE_DIRS
+  LIBAD9361_LIBRARIES
+)

--- a/cmake/Modules/FindIIO.cmake
+++ b/cmake/Modules/FindIIO.cmake
@@ -1,11 +1,44 @@
-# - Config file for the libiio package
-# It defines the following variables
-#  IIO_INCLUDE_DIRS - include directories for FooBar
-#  IIO_LIBRARIES    - libraries to link against
-#  IIO_FOUND     - system has libad9361 installed
+# - Find libiio
+# Find the native libiio includes and library
+#
+#  LIBIIO_FOUND       - True if libiio is found.
+#  LIBIIO_INCLUDE_DIR - Where to find ad9361.h.
+#  LIBIIO_LIBRARIES   - List of libraries when using libiio.
 
-find_library(IIO_LIBRARIES iio)
-find_path(IIO_INCLUDE_DIRS iio.h)
-if(IIO_LIBRARIES)
-	set(IIO_FOUND TRUE)
-endif(IIO_LIBRARIES)
+set(LIBIIO_NAMES iio)
+find_library(LIBIIO_LIBRARY
+  NAMES ${LIBIIO_NAMES}
+  PATHS /usr/lib
+        /usr/lib64
+        /usr/local/lib
+        /usr/local/lib64
+        /opt/local/lib
+        /opt/local/lib64
+)
+
+find_path(LIBIIO_INCLUDE_DIR iio.h
+  /usr/include
+  /usr/local/include
+  /opt/local/include
+)
+
+if (LIBIIO_INCLUDE_DIR AND LIBIIO_LIBRARY)
+  set(LIBIIO_FOUND TRUE)
+  set(LIBIIO_INCLUDE_DIRS ${LIBIIO_INCLUDE_DIR})
+  set(LIBIIO_LIBRARIES ${LIBIIO_LIBRARY})
+else ()
+  set(LIBIIO_FOUND FALSE)
+  set(LIBIIO_INCLUDE_DIR "")
+  set(LIBIIO_INCLUDE_DIRS "")
+  set(LIBIIO_LIBRARY "")
+  set(LIBIIO_LIBRARIES "")
+endif ()
+
+if (LIBIIO_FOUND)
+  message(STATUS "Found libiio library: ${LIBIIO_LIBRARIES}")
+endif ()
+
+mark_as_advanced(
+  LIBIIO_INCLUDE_DIRS
+  LIBIIO_LIBRARIES
+)

--- a/gr-iio/CMakeLists.txt
+++ b/gr-iio/CMakeLists.txt
@@ -22,11 +22,16 @@
 ########################################################################
 include(GrBoost)
 
+find_package(AD9361 QUIET)
 find_package(IIO)
 
-option(LIBAD9361_ENABLE "Build with libad9361-iio" ON)
-if (LIBAD9361_ENABLE)
-  find_package(AD9361)
+set(GR_IIO_DEPENDENCIES
+  Boost_FOUND
+  ENABLE_GNURADIO_RUNTIME
+  ENABLE_GR_BLOCKS
+  LIBIIO_FOUND)
+
+if (LIBAD9361_FOUND)
   list(APPEND GR_IIO_DEPENDENCIES LIBAD9361_FOUND)
 endif()
 
@@ -34,12 +39,7 @@ endif()
 # Register component
 ########################################################################
 include(GrComponent)
-GR_REGISTER_COMPONENT("gr-iio" ENABLE_GR_IIO
-  Boost_FOUND
-  ENABLE_GNURADIO_RUNTIME
-  ENABLE_GR_BLOCKS
-  IIO_FOUND
-)
+GR_REGISTER_COMPONENT("gr-iio" ENABLE_GR_IIO ${GR_IIO_DEPENDENCIES})
 
 SET(GR_PKG_IIO_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/iio)
 

--- a/gr-iio/CMakeLists.txt
+++ b/gr-iio/CMakeLists.txt
@@ -24,13 +24,6 @@ include(GrBoost)
 
 find_package(IIO)
 
-set(GR_IIO_DEPENDENCIES
-  Boost_FOUND
-  ENABLE_GNURADIO_RUNTIME
-  ENABLE_GR_BLOCKS
-  ENABLE_VOLK
-  IIO_FOUND)
-
 option(LIBAD9361_ENABLE "Build with libad9361-iio" ON)
 if (LIBAD9361_ENABLE)
   find_package(AD9361)
@@ -41,7 +34,12 @@ endif()
 # Register component
 ########################################################################
 include(GrComponent)
-GR_REGISTER_COMPONENT("gr-iio" ENABLE_GR_IIO ${GR_IIO_DEPENDENCIES})
+GR_REGISTER_COMPONENT("gr-iio" ENABLE_GR_IIO
+  Boost_FOUND
+  ENABLE_GNURADIO_RUNTIME
+  ENABLE_GR_BLOCKS
+  IIO_FOUND
+)
 
 SET(GR_PKG_IIO_EXAMPLES_DIR ${GR_PKG_DATA_DIR}/examples/iio)
 

--- a/gr-iio/include/gnuradio/iio/CMakeLists.txt
+++ b/gr-iio/include/gnuradio/iio/CMakeLists.txt
@@ -22,12 +22,17 @@
 ########################################################################
 install(FILES
   api.h
-  device_source.h device_sink.h
-  fmcomms2_source.h fmcomms2_sink.h
-  fmcomms5_source.h fmcomms5_sink.h
-  pluto_source.h pluto_sink.h
-  attr_source.h attr_sink.h
+  attr_sink.h
+  attr_source.h
   attr_updater.h
+  device_sink.h
+  device_source.h
   dds_control.h
+  fmcomms2_sink.h
+  fmcomms2_source.h
+  fmcomms5_sink.h
+  fmcomms5_source.h
+  pluto_sink.h
+  pluto_source.h
   DESTINATION ${GR_INCLUDE_DIR}/gnuradio/iio
 )

--- a/gr-iio/include/gnuradio/iio/attr_sink.h
+++ b/gr-iio/include/gnuradio/iio/attr_sink.h
@@ -43,7 +43,7 @@ namespace iio {
 class IIO_API attr_sink : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<attr_sink> sptr;
+    typedef std::shared_ptr<attr_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::attr_sink.

--- a/gr-iio/include/gnuradio/iio/attr_source.h
+++ b/gr-iio/include/gnuradio/iio/attr_source.h
@@ -41,7 +41,7 @@ namespace iio {
 class IIO_API attr_source : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<attr_source> sptr;
+    typedef std::shared_ptr<attr_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::attr_source.

--- a/gr-iio/include/gnuradio/iio/attr_updater.h
+++ b/gr-iio/include/gnuradio/iio/attr_updater.h
@@ -42,7 +42,7 @@ namespace iio {
 class IIO_API attr_updater : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<attr_updater> sptr;
+    typedef std::shared_ptr<attr_updater> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::attr_updater.

--- a/gr-iio/include/gnuradio/iio/dds_control.h
+++ b/gr-iio/include/gnuradio/iio/dds_control.h
@@ -42,7 +42,7 @@ namespace iio {
 class IIO_API dds_control : virtual public gr::block
 {
 public:
-    typedef boost::shared_ptr<dds_control> sptr;
+    typedef std::shared_ptr<dds_control> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::dds_control.

--- a/gr-iio/include/gnuradio/iio/device_sink.h
+++ b/gr-iio/include/gnuradio/iio/device_sink.h
@@ -46,7 +46,7 @@ namespace iio {
 class IIO_API device_sink : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<device_sink> sptr;
+    typedef std::shared_ptr<device_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::device.

--- a/gr-iio/include/gnuradio/iio/device_source.h
+++ b/gr-iio/include/gnuradio/iio/device_source.h
@@ -46,7 +46,7 @@ namespace iio {
 class IIO_API device_source : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<device_source> sptr;
+    typedef std::shared_ptr<device_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::device.

--- a/gr-iio/include/gnuradio/iio/fmcomms2_sink.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_sink.h
@@ -137,7 +137,7 @@ public:
 class IIO_API fmcomms2_sink_f32c : virtual public gr::hier_block2
 {
 public:
-  typedef std::shared_ptr<fmcomms2_sink_f32c> sptr;
+    typedef std::shared_ptr<fmcomms2_sink_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_sink.

--- a/gr-iio/include/gnuradio/iio/fmcomms2_sink.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_sink.h
@@ -44,7 +44,7 @@ namespace iio {
 class IIO_API fmcomms2_sink : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<fmcomms2_sink> sptr;
+    typedef std::shared_ptr<fmcomms2_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_sink.
@@ -137,7 +137,7 @@ public:
 class IIO_API fmcomms2_sink_f32c : virtual public gr::hier_block2
 {
 public:
-    typedef boost::shared_ptr<fmcomms2_sink_f32c> sptr;
+  typedef std::shared_ptr<fmcomms2_sink_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_sink.

--- a/gr-iio/include/gnuradio/iio/fmcomms2_source.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_source.h
@@ -172,7 +172,7 @@ public:
 class IIO_API fmcomms2_source_f32c : virtual public gr::hier_block2
 {
 public:
-  typedef std::shared_ptr<fmcomms2_source_f32c> sptr;
+    typedef std::shared_ptr<fmcomms2_source_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_source.

--- a/gr-iio/include/gnuradio/iio/fmcomms2_source.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms2_source.h
@@ -44,7 +44,7 @@ namespace iio {
 class IIO_API fmcomms2_source : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<fmcomms2_source> sptr;
+    typedef std::shared_ptr<fmcomms2_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_source.
@@ -172,7 +172,7 @@ public:
 class IIO_API fmcomms2_source_f32c : virtual public gr::hier_block2
 {
 public:
-    typedef boost::shared_ptr<fmcomms2_source_f32c> sptr;
+  typedef std::shared_ptr<fmcomms2_source_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_source.

--- a/gr-iio/include/gnuradio/iio/fmcomms5_sink.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms5_sink.h
@@ -161,7 +161,7 @@ public:
 class IIO_API fmcomms5_sink_f32c : virtual public gr::hier_block2
 {
 public:
-  typedef std::shared_ptr<fmcomms5_sink_f32c> sptr;
+    typedef std::shared_ptr<fmcomms5_sink_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms5_sink.

--- a/gr-iio/include/gnuradio/iio/fmcomms5_sink.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms5_sink.h
@@ -44,7 +44,7 @@ namespace iio {
 class IIO_API fmcomms5_sink : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<fmcomms5_sink> sptr;
+    typedef std::shared_ptr<fmcomms5_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms5_sink.
@@ -161,7 +161,7 @@ public:
 class IIO_API fmcomms5_sink_f32c : virtual public gr::hier_block2
 {
 public:
-    typedef boost::shared_ptr<fmcomms5_sink_f32c> sptr;
+  typedef std::shared_ptr<fmcomms5_sink_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms5_sink.

--- a/gr-iio/include/gnuradio/iio/fmcomms5_source.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms5_source.h
@@ -44,7 +44,7 @@ namespace iio {
 class IIO_API fmcomms5_source : virtual public gr::sync_block
 {
 public:
-    typedef boost::shared_ptr<fmcomms5_source> sptr;
+    typedef std::shared_ptr<fmcomms5_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::device.
@@ -212,7 +212,7 @@ public:
 class IIO_API fmcomms5_source_f32c : virtual public gr::hier_block2
 {
 public:
-    typedef boost::shared_ptr<fmcomms5_source_f32c> sptr;
+  typedef std::shared_ptr<fmcomms5_source_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::device.

--- a/gr-iio/include/gnuradio/iio/fmcomms5_source.h
+++ b/gr-iio/include/gnuradio/iio/fmcomms5_source.h
@@ -212,7 +212,7 @@ public:
 class IIO_API fmcomms5_source_f32c : virtual public gr::hier_block2
 {
 public:
-  typedef std::shared_ptr<fmcomms5_source_f32c> sptr;
+    typedef std::shared_ptr<fmcomms5_source_f32c> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::device.

--- a/gr-iio/include/gnuradio/iio/pluto_sink.h
+++ b/gr-iio/include/gnuradio/iio/pluto_sink.h
@@ -36,7 +36,7 @@ namespace iio {
 class IIO_API pluto_sink : virtual public gr::hier_block2
 {
 public:
-    typedef boost::shared_ptr<pluto_sink> sptr;
+    typedef std::shared_ptr<pluto_sink> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_sink.

--- a/gr-iio/include/gnuradio/iio/pluto_source.h
+++ b/gr-iio/include/gnuradio/iio/pluto_source.h
@@ -36,7 +36,7 @@ namespace iio {
 class IIO_API pluto_source : virtual public gr::hier_block2
 {
 public:
-    typedef boost::shared_ptr<pluto_source> sptr;
+    typedef std::shared_ptr<pluto_source> sptr;
 
     /*!
      * \brief Return a shared_ptr to a new instance of iio::fmcomms2_source.

--- a/gr-iio/lib/CMakeLists.txt
+++ b/gr-iio/lib/CMakeLists.txt
@@ -21,20 +21,12 @@
 # Setup library
 ########################################################################
 add_library(gnuradio-iio
-  device_source_impl.cc
-  device_sink_impl.cc
-  attr_source_impl.cc
   attr_sink_impl.cc
+  attr_source_impl.cc
   attr_updater_impl.cc
   dds_control.cc
-)
-
-target_link_libraries(gnuradio-iio PUBLIC
-  gnuradio-runtime
-  ${IIO_LIBRARIES}
-  ${GR_VOLK_LIB}
-  PRIVATE
-  gnuradio-blocks
+  device_sink_impl.cc
+  device_source_impl.cc
 )
 
 target_include_directories(gnuradio-iio
@@ -43,17 +35,25 @@ target_include_directories(gnuradio-iio
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   )
 
+target_link_libraries(gnuradio-iio PUBLIC
+  gnuradio-runtime
+  ${LIBIIO_LIBRARIES}
+  ${GR_VOLK_LIB}
+  PRIVATE
+  gnuradio-blocks
+)
+
 if(LIBAD9361_FOUND)
   target_sources(gnuradio-iio PRIVATE
-    fmcomms2_source_impl.cc
     fmcomms2_sink_impl.cc
-    fmcomms5_source_impl.cc
+    fmcomms2_source_impl.cc
     fmcomms5_sink_impl.cc
-    pluto_source_impl.cc
+    fmcomms5_source_impl.cc
     pluto_sink_impl.cc
+    pluto_source_impl.cc
   )
-  target_link_libraries(gnuradio-iio PUBLIC ${AD9361_LIBRARIES})
-  target_include_directories(gnuradio-iio PUBLIC ${AD9361_INCLUDE_DIRS})
+  target_include_directories(gnuradio-iio PUBLIC ${LIBAD9361_INCLUDE_DIRS})
+  target_link_libraries(gnuradio-iio PUBLIC ${LIBAD9361_LIBRARIES})
 endif(LIBAD9361_FOUND)
 
 #Add Windows DLL resource file if using MSVC

--- a/gr-iio/lib/attr_updater_impl.cc
+++ b/gr-iio/lib/attr_updater_impl.cc
@@ -95,7 +95,7 @@ bool attr_updater_impl::start()
         d_mtx.lock();
         d_finished = false;
         d_mtx.unlock();
-        d_thread = boost::shared_ptr<gr::thread::thread>(
+        d_thread = std::shared_ptr<gr::thread::thread>(
             new gr::thread::thread(boost::bind(&attr_updater_impl::run, this)));
     }
     return block::start();

--- a/gr-iio/lib/attr_updater_impl.h
+++ b/gr-iio/lib/attr_updater_impl.h
@@ -41,7 +41,7 @@ namespace gr {
       bool d_updated;
       pmt::pmt_t d_msg;
       std::mutex d_mtx;
-      boost::shared_ptr<gr::thread::thread> d_thread;
+      std::shared_ptr<gr::thread::thread> d_thread;
 
       void run();
 


### PR DESCRIPTION
**Updates for GNU Radio version >= 3.9 compatibility.**

- Use std::shared_ptr with GNU Radio version 3.9.
- Update CMakeLists to remove Volk.

**Use std::shared_ptr with GNU Radio 3.9.**

In the upcoming GNU Radio version 3.9 release, GNU Radio is switching from `boost::shared_pt`r to `std::shared_ptr`. 

Please see:

https://wiki.gnuradio.org/index.php/GNU_Radio_3.9_OOT_Module_Porting_Guide#C.2B.2B_Modernization

:boom:

**Update CMakeLists to remove Volk.**

Remove the flag `ENABLE_VOLK` from CMakeLists.txt.

:boom:

**Testing**

I have tested these changes by building GNU Radio version 3.9 (master) from source and applying these changes. The build works as expected. I can supply a Docker container that allows this testing to happen in an automated manor.

I used the commit hash `518aa489498ec692dee51bb69936b620660ba113` while building GNU Radio from source :nerd_face:.